### PR TITLE
Generic names in chat window. Peer instead of {username}

### DIFF
--- a/frontend/components/RTC/Chat/chat.tsx
+++ b/frontend/components/RTC/Chat/chat.tsx
@@ -91,7 +91,7 @@ export default function ChatPanel({
     };
 
     const onTyping = ({ from, typing }: { from: string; typing: boolean }) => {
-      setPeerTyping(typing ? `${from} is typing…` : null);
+      setPeerTyping(typing ? `Peer is typing…` : null);
       if (typing) {
         if (typingTimeoutRef.current) clearTimeout(typingTimeoutRef.current);
         typingTimeoutRef.current = setTimeout(() => setPeerTyping(null), 3000);
@@ -177,7 +177,7 @@ export default function ChatPanel({
                   <span>{m.text}</span>
                 ) : (
                   <>
-                    {!mine && <div className="text-[10px] text-white/60 mb-1">{m.from}</div>}
+                    {!mine && <div className="text-[10px] text-white/60 mb-1">Peer</div>}
                     <div>{m.text}</div>
                   </>
                 )}


### PR DESCRIPTION
Resolves #12 
It is now showing `peer` is typing instead of `{username}`. Anonymized names everywhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Typing indicator now shows a generic “Peer is typing…” instead of displaying the sender’s name.
  * Incoming (non-mine) messages display the sender label as “Peer” in the message header.
  * Delivers a cleaner, more uniform chat presentation and reduces visual noise.
  * Aligns chat wording to consistent terminology across typing indicators and message headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->