### PR TITLE
Fix: Deduplicate "User Joined" System Messages

### DIFF
--- a/backend/src/chat/chat.ts
+++ b/backend/src/chat/chat.ts
@@ -5,8 +5,13 @@ import type { Server, Socket } from "socket.io";
 export function joinChatRoom(socket: Socket, roomId: string, name: string) {
   if (!roomId) return;
   const room = `chat:${roomId}`;
+  // Only emit join message if this socket was not already in the room
+  const rooms = socket.rooms || new Set();
+  const alreadyInRoom = rooms.has(room);
   socket.join(room);
-  socket.nsp.in(room).emit("chat:system", { text: `${name} joined the chat`, ts: Date.now() });
+  if (!alreadyInRoom) {
+    socket.nsp.in(room).emit("chat:system", { text: `${name} joined the chat`, ts: Date.now() });
+  }
 }
 
 export function wireChat(io: Server, socket: Socket) {


### PR DESCRIPTION
Prevents duplicate "user joined" system messages in chat by ensuring the backend only emits the join message if the socket was not already in the room. This resolves repeated join notifications caused by reconnects or remounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents duplicate “joined” system messages when a user is already in the chat room, reducing notification noise.
  * Maintains normal join notifications when users actually join, ensuring consistent behavior.

* **Chores**
  * Minor internal logic adjustments to improve reliability and avoid redundant message emissions without changing public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes: #6