### PR TITLE
fix: Camera/Microphone toggle not updating states & simultaneous toggle error #3

### DIFF
--- a/frontend/components/RTC/Room.tsx
+++ b/frontend/components/RTC/Room.tsx
@@ -47,7 +47,9 @@ export default function Room({
   const [mySocketId, setMySocketId] = useState<string | null>(null);
 
   const [lobby, setLobby] = useState(true);
-  const [status, setStatus] = useState<string>("Waiting to connect you to someone…");
+  const [status, setStatus] = useState<string>(
+    "Waiting to connect you to someone…"
+  );
   const [showTimeoutAlert, setShowTimeoutAlert] = useState(false);
   const [timeoutMessage, setTimeoutMessage] = useState("");
 
@@ -69,17 +71,19 @@ export default function Room({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
+    if (e.key === "Escape") {
       handleCancelTimeout();
     }
   };
 
   // Initialize mic/cam states from props (DeviceCheck) when available.
-  const [micOn, setMicOn] = useState<boolean>(typeof audioOn === "boolean" ? audioOn : true);
-  const [camOn, setCamOn] = useState<boolean>(typeof videoOn === "boolean" ? videoOn : true);
+  const [micOn, setMicOn] = useState<boolean>(
+    typeof audioOn === "boolean" ? audioOn : true
+  );
+  const [camOn, setCamOn] = useState<boolean>(
+    typeof videoOn === "boolean" ? videoOn : true
+  );
   const [screenShareOn, setScreenShareOn] = useState(false);
-
-  
 
   // Peer mic indicator (keeping this; camera overlay removed per your request)
   const [peerMicOn, setPeerMicOn] = useState(true);
@@ -126,40 +130,43 @@ export default function Room({
       console.log("🎥 Remote video element found");
       if (v.srcObject !== remoteStreamRef.current) {
         console.log("🔗 Setting remote video srcObject");
-        console.log("📊 Remote stream tracks:", remoteStreamRef.current.getTracks().length);
+        console.log(
+          "📊 Remote stream tracks:",
+          remoteStreamRef.current.getTracks().length
+        );
         remoteStreamRef.current.getTracks().forEach((track, index) => {
           console.log(`📹 Track ${index}:`, {
             id: track.id,
             kind: track.kind,
             enabled: track.enabled,
             readyState: track.readyState,
-            settings: track.getSettings()
+            settings: track.getSettings(),
           });
         });
-        
+
         v.srcObject = remoteStreamRef.current;
         v.playsInline = true;
         v.play().catch((err) => {
           console.error("❌ Error playing remote video:", err);
         });
-        
+
         // Add event listeners to track video state changes
         v.onloadedmetadata = () => {
           console.log("📺 Remote video metadata loaded:", {
             videoWidth: v.videoWidth,
             videoHeight: v.videoHeight,
-            duration: v.duration
+            duration: v.duration,
           });
         };
-        
+
         v.onplay = () => {
           console.log("▶️ Remote video started playing");
         };
-        
+
         v.onpause = () => {
           console.log("⏸️ Remote video paused");
         };
-        
+
         v.onerror = (e) => {
           console.error("💥 Remote video error:", e);
         };
@@ -170,7 +177,7 @@ export default function Room({
           currentTime: v.currentTime,
           videoWidth: v.videoWidth,
           videoHeight: v.videoHeight,
-          readyState: v.readyState
+          readyState: v.readyState,
         });
       }
     } else {
@@ -208,7 +215,8 @@ export default function Room({
 
   function detachLocalPreview() {
     try {
-      const localStream = localVideoRef.current?.srcObject as MediaStream | null;
+      const localStream = localVideoRef.current
+        ?.srcObject as MediaStream | null;
       if (localStream) {
         localStream.getTracks().forEach((t) => {
           try {
@@ -222,7 +230,7 @@ export default function Room({
     } catch (err) {
       console.error("Error in detachLocalPreview:", err);
     }
-    
+
     if (localVideoRef.current) {
       try {
         localVideoRef.current.pause();
@@ -241,7 +249,7 @@ export default function Room({
     } catch (err) {
       console.error("Error stopping local video track:", err);
     }
-    
+
     try {
       if (localAudioTrack) {
         localAudioTrack.stop();
@@ -249,7 +257,7 @@ export default function Room({
     } catch (err) {
       console.error("Error stopping local audio track:", err);
     }
-    
+
     // Also stop any track in currentVideoTrackRef
     try {
       const currentTrack = currentVideoTrackRef.current;
@@ -265,7 +273,7 @@ export default function Room({
 
   function teardownPeers(reason = "teardown") {
     console.log("Tearing down peers, reason:", reason);
-    
+
     // Clean up all senders in both peer connections
     try {
       if (sendingPcRef.current) {
@@ -284,7 +292,7 @@ export default function Room({
         try {
           receivingPcRef.current.getSenders().forEach((sn) => {
             try {
-              receivingPcRef.current?.removeTrack(sn)
+              receivingPcRef.current?.removeTrack(sn);
             } catch (err) {
               console.error("Error removing receiver track:", err);
             }
@@ -295,7 +303,7 @@ export default function Room({
     } catch (err) {
       console.error("Error in peer connection cleanup:", err);
     }
-    
+
     // Clear peer connection refs
     sendingPcRef.current = null;
     receivingPcRef.current = null;
@@ -316,10 +324,10 @@ export default function Room({
         console.error("Error stopping remote tracks:", err);
       }
     }
-    
+
     // Reset remote stream
     remoteStreamRef.current = new MediaStream();
-    
+
     // Clear video elements
     if (remoteVideoRef.current) {
       remoteVideoRef.current.srcObject = null;
@@ -346,7 +354,9 @@ export default function Room({
 
     // Clean up screenshare streams
     if (localScreenShareStreamRef.current) {
-      localScreenShareStreamRef.current.getTracks().forEach((t: MediaStreamTrack) => t.stop());
+      localScreenShareStreamRef.current
+        .getTracks()
+        .forEach((t: MediaStreamTrack) => t.stop());
       localScreenShareStreamRef.current = null;
     }
     if (currentScreenShareTrackRef.current) {
@@ -355,7 +365,8 @@ export default function Room({
     }
 
     // Clear screenshare video elements
-    if (localScreenShareRef.current) localScreenShareRef.current.srcObject = null;
+    if (localScreenShareRef.current)
+      localScreenShareRef.current.srcObject = null;
 
     // Return to lobby
     setLobby(true);
@@ -377,41 +388,6 @@ export default function Room({
     } catch {}
   };
 
-//   // Ensure there's a stable outbound video transceiver/sender.
-// // This gives you a permanent "slot" to replaceTrack(null|track) without renegotiation.
-// function getOrCreateVideoSender(pc: RTCPeerConnection | null): RTCRtpSender | null {
-//   if (!pc) {
-//     console.warn("No peer connection provided to getOrCreateVideoSender");
-//     return null;
-//   }
-
-//   // If we already have a sender cached and still attached to this PC, reuse it
-//   if (videoSenderRef.current && pc.getSenders().includes(videoSenderRef.current)) {
-//     console.log("Reusing existing video sender");
-//     return videoSenderRef.current;
-//   }
-
-//   // Try to find an existing video sender
-//   const existing = pc.getSenders().find(
-//     (s) =>
-//       s.track?.kind === "video" ||
-//       (s as any)?.transceiver?.receiver?.track?.kind === "video"
-//   );
-//   if (existing) {
-//     console.log("Found existing video sender");
-//     videoSenderRef.current = existing;
-//     return existing;
-//   }
-
-//   // Create a dedicated transceiver for video with sendrecv,
-//   // so we can start sending later without renegotiation.
-//   console.log("Creating new video transceiver");
-//   const tx = pc.addTransceiver("video", { direction: "sendrecv" });
-//   videoSenderRef.current = tx.sender;
-//   console.log("Created video transceiver with sender:", tx.sender);
-//   return tx.sender;
-// }
-
   const toggleCam = async () => {
     const turningOn = !camOn;
     setCamOn(turningOn);
@@ -423,7 +399,9 @@ export default function Room({
         // (Re)acquire a real camera track
         let track = currentVideoTrackRef.current;
         if (!track || track.readyState === "ended") {
-          const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+          const stream = await navigator.mediaDevices.getUserMedia({
+            video: true,
+          });
           track = stream.getVideoTracks()[0];
           currentVideoTrackRef.current = track;
         }
@@ -431,8 +409,10 @@ export default function Room({
         // Update local PiP stream
         if (localVideoRef.current) {
           const ms =
-            (localVideoRef.current.srcObject as MediaStream) || new MediaStream();
-          if (!localVideoRef.current.srcObject) localVideoRef.current.srcObject = ms;
+            (localVideoRef.current.srcObject as MediaStream) ||
+            new MediaStream();
+          if (!localVideoRef.current.srcObject)
+            localVideoRef.current.srcObject = ms;
           ms.getVideoTracks().forEach((t) => ms.removeTrack(t));
           ms.addTrack(track);
           await localVideoRef.current.play().catch(() => {});
@@ -446,16 +426,16 @@ export default function Room({
           const sender = pc.addTrack(track);
           videoSenderRef.current = sender;
           console.log("Added new video track to existing connection");
-          
+
           // If we're adding a track to an existing connection, we might need to renegotiate
           if (sendingPcRef.current === pc) {
             // We're the caller, create new offer
             const offer = await pc.createOffer();
             await pc.setLocalDescription(offer);
-            socketRef.current?.emit("renegotiate-offer", { 
-              roomId, 
-              sdp: offer, 
-              role: "caller" 
+            socketRef.current?.emit("renegotiate-offer", {
+              roomId,
+              sdp: offer,
+              role: "caller",
             });
             console.log("📤 Sent renegotiation offer for camera turn on");
           }
@@ -493,7 +473,7 @@ export default function Room({
           }
           // leave audio track (if any) untouched
         }
-        
+
         // If we have any other video tracks anywhere, stop them too
         if (localVideoTrack) {
           try {
@@ -504,7 +484,7 @@ export default function Room({
     } catch (e: any) {
       console.error("toggleCam error", e);
       toast.error("Camera Error", {
-        description: e?.message || "Failed to toggle camera"
+        description: e?.message || "Failed to toggle camera",
       });
     }
   };
@@ -523,7 +503,7 @@ export default function Room({
           console.log("🎬 Starting screen capture...");
           const screenStream = await navigator.mediaDevices.getDisplayMedia({
             video: true,
-            audio: true // Include system audio if available
+            audio: true, // Include system audio if available
           });
 
           const screenTrack = screenStream.getVideoTracks()[0];
@@ -532,9 +512,9 @@ export default function Room({
             kind: screenTrack.kind,
             enabled: screenTrack.enabled,
             readyState: screenTrack.readyState,
-            settings: screenTrack.getSettings()
+            settings: screenTrack.getSettings(),
           });
-          
+
           currentScreenShareTrackRef.current = screenTrack;
           localScreenShareStreamRef.current = screenStream;
 
@@ -548,20 +528,34 @@ export default function Room({
           // Replace the existing video track with screen share track
           if (videoSenderRef.current) {
             console.log("📡 Video sender found, replacing track");
-            console.log("🔄 Current video sender track:", videoSenderRef.current.track);
-            console.log("🔗 Peer connection state:", (sendingPcRef.current || receivingPcRef.current)?.connectionState);
-            
+            console.log(
+              "🔄 Current video sender track:",
+              videoSenderRef.current.track
+            );
+            console.log(
+              "🔗 Peer connection state:",
+              (sendingPcRef.current || receivingPcRef.current)?.connectionState
+            );
+
             await videoSenderRef.current.replaceTrack(screenTrack);
-            console.log("✅ Successfully replaced video track with screen share track");
+            console.log(
+              "✅ Successfully replaced video track with screen share track"
+            );
             console.log("📊 New track settings:", screenTrack.getSettings());
-            
+
             toast.success("Screen Share Started", {
-              description: "You are now sharing your screen"
+              description: "You are now sharing your screen",
             });
-            
+
             // Verify the replacement
-            console.log("🔍 Video sender track after replacement:", videoSenderRef.current.track);
-            console.log("🎯 Track ID matches:", videoSenderRef.current.track?.id === screenTrack.id);
+            console.log(
+              "🔍 Video sender track after replacement:",
+              videoSenderRef.current.track
+            );
+            console.log(
+              "🎯 Track ID matches:",
+              videoSenderRef.current.track?.id === screenTrack.id
+            );
           } else {
             console.warn("❌ No video sender found, trying to create one");
             const pc = sendingPcRef.current || receivingPcRef.current;
@@ -570,24 +564,24 @@ export default function Room({
               const sender = pc.addTrack(screenTrack, screenStream);
               videoSenderRef.current = sender;
               console.log("✅ Created new video sender for screen share");
-              
+
               // Force renegotiation since we added a new track
               console.log("🔄 Triggering renegotiation for new track");
               if (sendingPcRef.current === pc) {
                 // We're the caller, create new offer
                 const offer = await pc.createOffer();
                 await pc.setLocalDescription(offer);
-                socketRef.current?.emit("renegotiate-offer", { 
-                  roomId, 
-                  sdp: offer, 
-                  role: "caller" 
+                socketRef.current?.emit("renegotiate-offer", {
+                  roomId,
+                  sdp: offer,
+                  role: "caller",
                 });
                 console.log("📤 Sent renegotiation offer");
               }
             } else {
               console.error("💥 No peer connection available for screen share");
               toast.error("Screen Share Error", {
-                description: "No peer connection available for screen sharing"
+                description: "No peer connection available for screen sharing",
               });
             }
           }
@@ -597,7 +591,7 @@ export default function Room({
             const mediaState = {
               isScreenSharing: true,
               micOn,
-              camOn: false // Camera is replaced by screen share
+              camOn: false, // Camera is replaced by screen share
             };
             console.log("📡 Emitting media-state-change:", mediaState);
             socket.emit("media-state-change", mediaState);
@@ -606,37 +600,49 @@ export default function Room({
           // Handle screen share ending (user clicks "Stop sharing" in browser)
           screenTrack.onended = async () => {
             setScreenShareOn(false);
-            
+
             // Restore original camera track when screen share ends
             let cameraTrack = currentVideoTrackRef.current;
             if (!cameraTrack || cameraTrack.readyState === "ended") {
               // Get a new camera track if needed and camera should be on
               if (camOn) {
                 try {
-                  const cameraStream = await navigator.mediaDevices.getUserMedia({ video: true });
+                  const cameraStream =
+                    await navigator.mediaDevices.getUserMedia({ video: true });
                   cameraTrack = cameraStream.getVideoTracks()[0];
                   currentVideoTrackRef.current = cameraTrack;
-                  
+
                   // Update local preview
                   if (localVideoRef.current) {
-                    const localStream = localVideoRef.current.srcObject as MediaStream || new MediaStream();
-                    localStream.getVideoTracks().forEach(t => localStream.removeTrack(t));
+                    const localStream =
+                      (localVideoRef.current.srcObject as MediaStream) ||
+                      new MediaStream();
+                    localStream
+                      .getVideoTracks()
+                      .forEach((t) => localStream.removeTrack(t));
                     localStream.addTrack(cameraTrack);
-                    if (!localVideoRef.current.srcObject) localVideoRef.current.srcObject = localStream;
+                    if (!localVideoRef.current.srcObject)
+                      localVideoRef.current.srcObject = localStream;
                   }
                 } catch (err: any) {
-                  console.error("Error getting camera after screen share:", err);
+                  console.error(
+                    "Error getting camera after screen share:",
+                    err
+                  );
                   toast.error("Camera Error", {
-                    description: "Failed to restore camera after screen sharing"
+                    description:
+                      "Failed to restore camera after screen sharing",
                   });
                   cameraTrack = null;
                 }
               }
             }
-            
+
             // Replace screen share track with camera track (or null if camera disabled)
             if (videoSenderRef.current) {
-              await videoSenderRef.current.replaceTrack(camOn ? cameraTrack : null);
+              await videoSenderRef.current.replaceTrack(
+                camOn ? cameraTrack : null
+              );
             }
 
             // Clean up screen share resources
@@ -647,7 +653,7 @@ export default function Room({
             localScreenShareStreamRef.current = null;
 
             toast.success("Screen Share Stopped", {
-              description: "You have stopped sharing your screen"
+              description: "You have stopped sharing your screen",
             });
 
             // Notify peer that screenshare stopped
@@ -655,15 +661,14 @@ export default function Room({
               socket.emit("media-state-change", {
                 isScreenSharing: false,
                 micOn,
-                camOn
+                camOn,
               });
             }
           };
-
         } catch (error: any) {
           console.error("Error starting screen share:", error);
           toast.error("Screen Share Error", {
-            description: error?.message || "Failed to start screen sharing"
+            description: error?.message || "Failed to start screen sharing",
           });
           setScreenShareOn(false);
         }
@@ -673,7 +678,9 @@ export default function Room({
           currentScreenShareTrackRef.current.stop();
         }
         if (localScreenShareStreamRef.current) {
-          localScreenShareStreamRef.current.getTracks().forEach(t => t.stop());
+          localScreenShareStreamRef.current
+            .getTracks()
+            .forEach((t) => t.stop());
           localScreenShareStreamRef.current = null;
         }
         if (localScreenShareRef.current) {
@@ -686,21 +693,32 @@ export default function Room({
           // Get a new camera track if needed and camera should be on
           if (camOn) {
             try {
-              const cameraStream = await navigator.mediaDevices.getUserMedia({ video: true });
+              const cameraStream = await navigator.mediaDevices.getUserMedia({
+                video: true,
+              });
               cameraTrack = cameraStream.getVideoTracks()[0];
               currentVideoTrackRef.current = cameraTrack;
-              
+
               // Update local preview
               if (localVideoRef.current) {
-                const localStream = localVideoRef.current.srcObject as MediaStream || new MediaStream();
-                localStream.getVideoTracks().forEach(t => localStream.removeTrack(t));
+                const localStream =
+                  (localVideoRef.current.srcObject as MediaStream) ||
+                  new MediaStream();
+                localStream
+                  .getVideoTracks()
+                  .forEach((t) => localStream.removeTrack(t));
                 localStream.addTrack(cameraTrack);
-                if (!localVideoRef.current.srcObject) localVideoRef.current.srcObject = localStream;
+                if (!localVideoRef.current.srcObject)
+                  localVideoRef.current.srcObject = localStream;
               }
             } catch (err: any) {
-              console.error("Error getting camera after stopping screen share:", err);
+              console.error(
+                "Error getting camera after stopping screen share:",
+                err
+              );
               toast.error("Camera Error", {
-                description: "Failed to restore camera after stopping screen share"
+                description:
+                  "Failed to restore camera after stopping screen share",
               });
               cameraTrack = null;
             }
@@ -717,7 +735,7 @@ export default function Room({
           socket.emit("media-state-change", {
             isScreenSharing: false,
             micOn,
-            camOn
+            camOn,
           });
         }
 
@@ -726,7 +744,7 @@ export default function Room({
     } catch (error: any) {
       console.error("toggleScreenShare error", error);
       toast.error("Screen Share Error", {
-        description: error?.message || "Failed to toggle screen sharing"
+        description: error?.message || "Failed to toggle screen sharing",
       });
       setScreenShareOn(false);
     }
@@ -813,9 +831,9 @@ export default function Room({
       s.emit("chat:join", { roomId: rid, name });
       setLobby(false);
       setStatus("Connecting…");
-      
+
       toast.success("Connected!", {
-        description: "You've been connected to someone"
+        description: "You've been connected to someone",
       });
 
       const pc = new RTCPeerConnection();
@@ -830,62 +848,98 @@ export default function Room({
         pc.addTrack(localAudioTrack);
         console.log("Added local audio track to caller PC");
       }
-      
+
       // Handle video track - ensure we have a fresh track if camera is on
       if (camOn) {
         console.log("📹 Caller: Camera is ON, will add video track");
         let videoTrack = currentVideoTrackRef.current;
-        
+
         // If we don't have a valid video track, create a new one
         if (!videoTrack || videoTrack.readyState === "ended") {
           console.log("Creating new video track for caller connection");
           try {
-            const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+            const stream = await navigator.mediaDevices.getUserMedia({
+              video: true,
+            });
             videoTrack = stream.getVideoTracks()[0];
             currentVideoTrackRef.current = videoTrack;
-            console.log("📹 Created new video track:", videoTrack.id, "readyState:", videoTrack.readyState);
-            
+            console.log(
+              "📹 Created new video track:",
+              videoTrack.id,
+              "readyState:",
+              videoTrack.readyState
+            );
+
             // Update local preview with new track
             if (localVideoRef.current) {
               console.log("🎥 Updating local video preview with new track");
-              const localStream = localVideoRef.current.srcObject as MediaStream || new MediaStream();
+              const localStream =
+                (localVideoRef.current.srcObject as MediaStream) ||
+                new MediaStream();
               const oldTracks = localStream.getVideoTracks();
-              console.log("🗑️ Removing", oldTracks.length, "old video tracks from local preview");
-              localStream.getVideoTracks().forEach(t => localStream.removeTrack(t));
+              console.log(
+                "🗑️ Removing",
+                oldTracks.length,
+                "old video tracks from local preview"
+              );
+              localStream
+                .getVideoTracks()
+                .forEach((t) => localStream.removeTrack(t));
               localStream.addTrack(videoTrack);
               console.log("➕ Added new video track to local preview stream");
-              if (!localVideoRef.current.srcObject) localVideoRef.current.srcObject = localStream;
+              if (!localVideoRef.current.srcObject)
+                localVideoRef.current.srcObject = localStream;
               await localVideoRef.current.play().catch(() => {});
               console.log("▶️ Local video play completed");
-              
+
               // Additional debug: Check the video element state
               setTimeout(() => {
                 if (localVideoRef.current) {
                   console.log("🔍 Caller local video element check:");
-                  console.log("   - srcObject exists:", !!localVideoRef.current.srcObject);
-                  console.log("   - videoWidth:", localVideoRef.current.videoWidth);
-                  console.log("   - videoHeight:", localVideoRef.current.videoHeight);
-                  console.log("   - readyState:", localVideoRef.current.readyState);
+                  console.log(
+                    "   - srcObject exists:",
+                    !!localVideoRef.current.srcObject
+                  );
+                  console.log(
+                    "   - videoWidth:",
+                    localVideoRef.current.videoWidth
+                  );
+                  console.log(
+                    "   - videoHeight:",
+                    localVideoRef.current.videoHeight
+                  );
+                  console.log(
+                    "   - readyState:",
+                    localVideoRef.current.readyState
+                  );
                   console.log("   - paused:", localVideoRef.current.paused);
                   if (localVideoRef.current.srcObject) {
-                    const stream = localVideoRef.current.srcObject as MediaStream;
+                    const stream = localVideoRef.current
+                      .srcObject as MediaStream;
                     console.log("   - stream active:", stream.active);
-                    console.log("   - video tracks:", stream.getVideoTracks().length);
+                    console.log(
+                      "   - video tracks:",
+                      stream.getVideoTracks().length
+                    );
                     stream.getVideoTracks().forEach((track, i) => {
-                      console.log(`   - track ${i}: enabled=${track.enabled}, readyState=${track.readyState}`);
+                      console.log(
+                        `   - track ${i}: enabled=${track.enabled}, readyState=${track.readyState}`
+                      );
                     });
                   }
                 }
               }, 100);
             } else {
-              console.warn("⚠️ Local video ref not available for preview update");
+              console.warn(
+                "⚠️ Local video ref not available for preview update"
+              );
             }
           } catch (err) {
             console.error("Error creating video track for caller:", err);
             videoTrack = null;
           }
         }
-        
+
         // Add the video track to the connection
         if (videoTrack && videoTrack.readyState === "live") {
           const vs = pc.addTrack(videoTrack);
@@ -904,55 +958,65 @@ export default function Room({
         console.log("🔄 Track readyState:", e.track.readyState);
         console.log("📡 Stream count:", e.streams.length);
         console.log("🆔 Track ID:", e.track.id);
-        
+
         // Check if this could be a screen share track
         const settings = e.track.getSettings();
-        const isLikelyScreenShare = settings.displaySurface !== undefined || 
-                                   (settings.width && settings.width > 1920) ||
-                                   (settings.height && settings.height > 1080);
+        const isLikelyScreenShare =
+          settings.displaySurface !== undefined ||
+          (settings.width && settings.width > 1920) ||
+          (settings.height && settings.height > 1080);
         console.log("🖥️ Likely screen share track:", isLikelyScreenShare);
-        
+
         // For screen sharing implementation, we handle all video tracks in the main remote stream
         // The peer will replace their video track with screen share track using replaceTrack
         if (!remoteStreamRef.current) {
           console.log("📺 Creating remote stream for new track");
           remoteStreamRef.current = new MediaStream();
         }
-        
+
         // Remove any existing tracks of the same kind to avoid duplicates
-        if (e.track.kind === 'video') {
+        if (e.track.kind === "video") {
           const existingVideoTracks = remoteStreamRef.current.getVideoTracks();
-          console.log(`🗑️ Removing ${existingVideoTracks.length} existing video tracks`);
-          existingVideoTracks.forEach(track => {
+          console.log(
+            `🗑️ Removing ${existingVideoTracks.length} existing video tracks`
+          );
+          existingVideoTracks.forEach((track) => {
             console.log("🗑️ Removing existing video track:", track.id);
             remoteStreamRef.current?.removeTrack(track);
           });
         }
-        
+
         console.log("➕ Adding new track to remote stream");
         remoteStreamRef.current.addTrack(e.track);
-        console.log("📊 Total tracks in remote stream:", remoteStreamRef.current.getTracks().length);
-        
+        console.log(
+          "📊 Total tracks in remote stream:",
+          remoteStreamRef.current.getTracks().length
+        );
+
         // Add track event listeners
         e.track.onended = () => {
           console.log("🔚 Remote track ended:", e.track.id);
         };
-        
+
         e.track.onmute = () => {
           console.log("🔇 Remote track muted:", e.track.id);
         };
-        
+
         e.track.onunmute = () => {
           console.log("🔊 Remote track unmuted:", e.track.id);
         };
-        
+
         ensureRemoteStream(); // Ensure video element has the updated stream
         console.log("✅ Track processing complete");
       };
 
       pc.onicecandidate = (e) => {
         if (e.candidate) {
-          s.emit("add-ice-candidate", { candidate: e.candidate, type: "sender", roomId: rid });
+          s.emit("add-ice-candidate", {
+            candidate: e.candidate,
+            type: "sender",
+            roomId: rid,
+          });
         }
       };
 
@@ -973,9 +1037,9 @@ export default function Room({
       s.emit("chat:join", { roomId: rid, name });
       setLobby(false);
       setStatus("Connecting…");
-      
+
       toast.success("Connected!", {
-        description: "You've been connected to someone"
+        description: "You've been connected to someone",
       });
 
       const pc = new RTCPeerConnection();
@@ -990,62 +1054,98 @@ export default function Room({
         pc.addTrack(localAudioTrack);
         console.log("Added local audio track to answerer PC");
       }
-      
+
       // Handle video track - ensure we have a fresh track if camera is on
       if (camOn) {
         console.log("📹 Answerer: Camera is ON, will add video track");
         let videoTrack = currentVideoTrackRef.current;
-        
+
         // If we don't have a valid video track, create a new one
         if (!videoTrack || videoTrack.readyState === "ended") {
           console.log("Creating new video track for answerer connection");
           try {
-            const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+            const stream = await navigator.mediaDevices.getUserMedia({
+              video: true,
+            });
             videoTrack = stream.getVideoTracks()[0];
             currentVideoTrackRef.current = videoTrack;
-            console.log("📹 Created new video track:", videoTrack.id, "readyState:", videoTrack.readyState);
-            
+            console.log(
+              "📹 Created new video track:",
+              videoTrack.id,
+              "readyState:",
+              videoTrack.readyState
+            );
+
             // Update local preview with new track
             if (localVideoRef.current) {
               console.log("🎥 Updating local video preview with new track");
-              const localStream = localVideoRef.current.srcObject as MediaStream || new MediaStream();
+              const localStream =
+                (localVideoRef.current.srcObject as MediaStream) ||
+                new MediaStream();
               const oldTracks = localStream.getVideoTracks();
-              console.log("🗑️ Removing", oldTracks.length, "old video tracks from local preview");
-              localStream.getVideoTracks().forEach(t => localStream.removeTrack(t));
+              console.log(
+                "🗑️ Removing",
+                oldTracks.length,
+                "old video tracks from local preview"
+              );
+              localStream
+                .getVideoTracks()
+                .forEach((t) => localStream.removeTrack(t));
               localStream.addTrack(videoTrack);
               console.log("➕ Added new video track to local preview stream");
-              if (!localVideoRef.current.srcObject) localVideoRef.current.srcObject = localStream;
+              if (!localVideoRef.current.srcObject)
+                localVideoRef.current.srcObject = localStream;
               await localVideoRef.current.play().catch(() => {});
               console.log("▶️ Local video play completed");
-              
+
               // Additional debug: Check the video element state
               setTimeout(() => {
                 if (localVideoRef.current) {
                   console.log("🔍 Answerer local video element check:");
-                  console.log("   - srcObject exists:", !!localVideoRef.current.srcObject);
-                  console.log("   - videoWidth:", localVideoRef.current.videoWidth);
-                  console.log("   - videoHeight:", localVideoRef.current.videoHeight);
-                  console.log("   - readyState:", localVideoRef.current.readyState);
+                  console.log(
+                    "   - srcObject exists:",
+                    !!localVideoRef.current.srcObject
+                  );
+                  console.log(
+                    "   - videoWidth:",
+                    localVideoRef.current.videoWidth
+                  );
+                  console.log(
+                    "   - videoHeight:",
+                    localVideoRef.current.videoHeight
+                  );
+                  console.log(
+                    "   - readyState:",
+                    localVideoRef.current.readyState
+                  );
                   console.log("   - paused:", localVideoRef.current.paused);
                   if (localVideoRef.current.srcObject) {
-                    const stream = localVideoRef.current.srcObject as MediaStream;
+                    const stream = localVideoRef.current
+                      .srcObject as MediaStream;
                     console.log("   - stream active:", stream.active);
-                    console.log("   - video tracks:", stream.getVideoTracks().length);
+                    console.log(
+                      "   - video tracks:",
+                      stream.getVideoTracks().length
+                    );
                     stream.getVideoTracks().forEach((track, i) => {
-                      console.log(`   - track ${i}: enabled=${track.enabled}, readyState=${track.readyState}`);
+                      console.log(
+                        `   - track ${i}: enabled=${track.enabled}, readyState=${track.readyState}`
+                      );
                     });
                   }
                 }
               }, 100);
             } else {
-              console.warn("⚠️ Local video ref not available for preview update");
+              console.warn(
+                "⚠️ Local video ref not available for preview update"
+              );
             }
           } catch (err) {
             console.error("Error creating video track for answerer:", err);
             videoTrack = null;
           }
         }
-        
+
         // Add the video track to the connection
         if (videoTrack && videoTrack.readyState === "live") {
           const vs = pc.addTrack(videoTrack);
@@ -1058,8 +1158,8 @@ export default function Room({
 
       await pc.setRemoteDescription(new RTCSessionDescription(remoteSdp));
 
-  // capture peer id reference if provided
-  peerIdRef.current = rid || peerIdRef.current;
+      // capture peer id reference if provided
+      peerIdRef.current = rid || peerIdRef.current;
 
       ensureRemoteStream();
       pc.ontrack = (e) => {
@@ -1069,55 +1169,65 @@ export default function Room({
         console.log("🔄 Track readyState:", e.track.readyState);
         console.log("📡 Stream count:", e.streams.length);
         console.log("🆔 Track ID:", e.track.id);
-        
+
         // Check if this could be a screen share track
         const settings = e.track.getSettings();
-        const isLikelyScreenShare = settings.displaySurface !== undefined || 
-                                   (settings.width && settings.width > 1920) ||
-                                   (settings.height && settings.height > 1080);
+        const isLikelyScreenShare =
+          settings.displaySurface !== undefined ||
+          (settings.width && settings.width > 1920) ||
+          (settings.height && settings.height > 1080);
         console.log("🖥️ Likely screen share track:", isLikelyScreenShare);
-        
+
         // For screen sharing implementation, we handle all video tracks in the main remote stream
         // The peer will replace their video track with screen share track using replaceTrack
         if (!remoteStreamRef.current) {
           console.log("📺 Creating remote stream for new track");
           remoteStreamRef.current = new MediaStream();
         }
-        
+
         // Remove any existing tracks of the same kind to avoid duplicates
-        if (e.track.kind === 'video') {
+        if (e.track.kind === "video") {
           const existingVideoTracks = remoteStreamRef.current.getVideoTracks();
-          console.log(`🗑️ Removing ${existingVideoTracks.length} existing video tracks`);
-          existingVideoTracks.forEach(track => {
+          console.log(
+            `🗑️ Removing ${existingVideoTracks.length} existing video tracks`
+          );
+          existingVideoTracks.forEach((track) => {
             console.log("🗑️ Removing existing video track:", track.id);
             remoteStreamRef.current?.removeTrack(track);
           });
         }
-        
+
         console.log("➕ Adding new track to remote stream");
         remoteStreamRef.current.addTrack(e.track);
-        console.log("📊 Total tracks in remote stream:", remoteStreamRef.current.getTracks().length);
-        
+        console.log(
+          "📊 Total tracks in remote stream:",
+          remoteStreamRef.current.getTracks().length
+        );
+
         // Add track event listeners
         e.track.onended = () => {
           console.log("🔚 Remote track ended:", e.track.id);
         };
-        
+
         e.track.onmute = () => {
           console.log("🔇 Remote track muted:", e.track.id);
         };
-        
+
         e.track.onunmute = () => {
           console.log("🔊 Remote track unmuted:", e.track.id);
         };
-        
+
         ensureRemoteStream(); // Ensure video element has the updated stream
         console.log("✅ Track processing complete");
       };
 
       pc.onicecandidate = (e) => {
         if (e.candidate) {
-          s.emit("add-ice-candidate", { candidate: e.candidate, type: "receiver", roomId: rid });
+          s.emit("add-ice-candidate", {
+            candidate: e.candidate,
+            type: "receiver",
+            roomId: rid,
+          });
         }
       };
 
@@ -1195,82 +1305,116 @@ export default function Room({
     // partner left
     s.on("partner:left", () => {
       console.log("👋 PARTNER LEFT - Preserving states and cleaning up");
-      
+
       toast.warning("Partner Left", {
-        description: "Your partner has left the call"
+        description: "Your partner has left the call",
       });
-      
+
       // Get the actual current states - check if we have active tracks, not just the state variables
-      const actualCamState = !!(currentVideoTrackRef.current && currentVideoTrackRef.current.readyState === "live" && camOn);
-      const actualMicState = !!(localAudioTrack && localAudioTrack.readyState === "live" && micOn);
-      
+      const actualCamState = !!(
+        currentVideoTrackRef.current &&
+        currentVideoTrackRef.current.readyState === "live" &&
+        camOn
+      );
+      const actualMicState = !!(
+        localAudioTrack &&
+        localAudioTrack.readyState === "live" &&
+        micOn
+      );
+
       console.log("🔄 Partner left - State check:");
       console.log("   - camOn state:", camOn);
-      console.log("   - currentVideoTrack exists:", !!currentVideoTrackRef.current);
-      console.log("   - currentVideoTrack readyState:", currentVideoTrackRef.current?.readyState);
+      console.log(
+        "   - currentVideoTrack exists:",
+        !!currentVideoTrackRef.current
+      );
+      console.log(
+        "   - currentVideoTrack readyState:",
+        currentVideoTrackRef.current?.readyState
+      );
       console.log("   - actual cam state:", actualCamState);
       console.log("   - actual mic state:", actualMicState);
-      
+
       handleNextConnection(actualCamState, actualMicState, "partner-left"); // Preserve actual states when partner leaves
     });
 
     // peer mic state (optional UI)
-    s.on("peer:media-state", ({ state }: { state: { micOn?: boolean; camOn?: boolean } }) => {
-      if (typeof state?.micOn === "boolean") setPeerMicOn(state.micOn);
-      if (typeof state?.camOn === "boolean") setPeerCamOn(state.camOn);
-    });
+    s.on(
+      "peer:media-state",
+      ({ state }: { state: { micOn?: boolean; camOn?: boolean } }) => {
+        if (typeof state?.micOn === "boolean") setPeerMicOn(state.micOn);
+        if (typeof state?.camOn === "boolean") setPeerCamOn(state.camOn);
+      }
+    );
     s.on("media:mic", ({ on }: { on: boolean }) => setPeerMicOn(!!on));
     s.on("media:cam", ({ on }: { on: boolean }) => setPeerCamOn(!!on));
 
     // New media state change handlers
-    s.on("peer-media-state-change", ({ isScreenSharing, micOn: peerMic, camOn: peerCam, from, userId }) => {
-      console.log("🔄 Peer media state changed:", { isScreenSharing, peerMic, peerCam, from, userId });
-      console.log("📺 Setting peerScreenShareOn to:", isScreenSharing);
-      console.log("🎤 Setting peerMicOn to:", peerMic);
-      console.log("📹 Setting peerCamOn to:", peerCam);
-      
-      if (typeof isScreenSharing === "boolean") {
-        setPeerScreenShareOn(isScreenSharing);
-        console.log("✅ Updated peerScreenShareOn state to:", isScreenSharing);
-      }
-      if (typeof peerMic === "boolean") {
-        setPeerMicOn(peerMic);
-        console.log("✅ Updated peerMicOn state to:", peerMic);
-      }
-      if (typeof peerCam === "boolean") {
-        setPeerCamOn(peerCam);
-        console.log("✅ Updated peerCamOn state to:", peerCam);
-      }
-      
-      // Log current remote stream state
-      if (remoteStreamRef.current) {
-        const videoTracks = remoteStreamRef.current.getVideoTracks();
-        const audioTracks = remoteStreamRef.current.getAudioTracks();
-        console.log("📡 Current remote stream - Video tracks:", videoTracks.length, "Audio tracks:", audioTracks.length);
-        videoTracks.forEach((track, index) => {
-          console.log(`📹 Video track ${index}:`, {
-            id: track.id,
-            kind: track.kind,
-            enabled: track.enabled,
-            readyState: track.readyState,
-            settings: track.getSettings()
+    s.on(
+      "peer-media-state-change",
+      ({ isScreenSharing, micOn: peerMic, camOn: peerCam, from, userId }) => {
+        console.log("🔄 Peer media state changed:", {
+          isScreenSharing,
+          peerMic,
+          peerCam,
+          from,
+          userId,
+        });
+        console.log("📺 Setting peerScreenShareOn to:", isScreenSharing);
+        console.log("🎤 Setting peerMicOn to:", peerMic);
+        console.log("📹 Setting peerCamOn to:", peerCam);
+
+        if (typeof isScreenSharing === "boolean") {
+          setPeerScreenShareOn(isScreenSharing);
+          console.log(
+            "✅ Updated peerScreenShareOn state to:",
+            isScreenSharing
+          );
+        }
+        if (typeof peerMic === "boolean") {
+          setPeerMicOn(peerMic);
+          console.log("✅ Updated peerMicOn state to:", peerMic);
+        }
+        if (typeof peerCam === "boolean") {
+          setPeerCamOn(peerCam);
+          console.log("✅ Updated peerCamOn state to:", peerCam);
+        }
+
+        // Log current remote stream state
+        if (remoteStreamRef.current) {
+          const videoTracks = remoteStreamRef.current.getVideoTracks();
+          const audioTracks = remoteStreamRef.current.getAudioTracks();
+          console.log(
+            "📡 Current remote stream - Video tracks:",
+            videoTracks.length,
+            "Audio tracks:",
+            audioTracks.length
+          );
+          videoTracks.forEach((track, index) => {
+            console.log(`📹 Video track ${index}:`, {
+              id: track.id,
+              kind: track.kind,
+              enabled: track.enabled,
+              readyState: track.readyState,
+              settings: track.getSettings(),
+            });
           });
-        });
-      } else {
-        console.log("❌ No remote stream available");
+        } else {
+          console.log("❌ No remote stream available");
+        }
+
+        // Log remote video element state
+        if (remoteVideoRef.current) {
+          console.log("🎥 Remote video element:", {
+            srcObject: !!remoteVideoRef.current.srcObject,
+            videoWidth: remoteVideoRef.current.videoWidth,
+            videoHeight: remoteVideoRef.current.videoHeight,
+            paused: remoteVideoRef.current.paused,
+            currentTime: remoteVideoRef.current.currentTime,
+          });
+        }
       }
-      
-      // Log remote video element state
-      if (remoteVideoRef.current) {
-        console.log("🎥 Remote video element:", {
-          srcObject: !!remoteVideoRef.current.srcObject,
-          videoWidth: remoteVideoRef.current.videoWidth,
-          videoHeight: remoteVideoRef.current.videoHeight,
-          paused: remoteVideoRef.current.paused,
-          currentTime: remoteVideoRef.current.currentTime
-        });
-      }
-    });
+    );
 
     s.on("room-state-update", ({ roomId: rid, users }) => {
       console.log("Room state updated:", rid, users);
@@ -1278,7 +1422,9 @@ export default function Room({
     });
 
     // Screen share events (legacy - keeping for compatibility)
-    s.on("screen:state", ({ on }: { on: boolean }) => setPeerScreenShareOn(!!on));
+    s.on("screen:state", ({ on }: { on: boolean }) =>
+      setPeerScreenShareOn(!!on)
+    );
 
     const onBeforeUnload = () => {
       try {
@@ -1343,9 +1489,17 @@ export default function Room({
 
   // --- Actions --------------------------------------------------------------
 
-  function handleNextConnection(currentCamState: boolean, currentMicState: boolean, reason: "next" | "partner-left" = "next") {
-    console.log("🔄 HANDLE_NEXT_CONNECTION START:", { currentCamState, currentMicState, reason });
-    
+  function handleNextConnection(
+    currentCamState: boolean,
+    currentMicState: boolean,
+    reason: "next" | "partner-left" = "next"
+  ) {
+    console.log("🔄 HANDLE_NEXT_CONNECTION START:", {
+      currentCamState,
+      currentMicState,
+      reason,
+    });
+
     // Clean up peer connections but preserve local tracks and states
     try {
       if (sendingPcRef.current) {
@@ -1364,7 +1518,7 @@ export default function Room({
         try {
           receivingPcRef.current.getSenders().forEach((sn) => {
             try {
-              receivingPcRef.current?.removeTrack(sn)
+              receivingPcRef.current?.removeTrack(sn);
             } catch (err) {
               console.error("Error removing receiver track:", err);
             }
@@ -1375,7 +1529,7 @@ export default function Room({
     } catch (err) {
       console.error("Error in peer connection cleanup:", err);
     }
-    
+
     // Clear peer connection refs
     sendingPcRef.current = null;
     receivingPcRef.current = null;
@@ -1396,10 +1550,10 @@ export default function Room({
         console.error("Error stopping remote tracks:", err);
       }
     }
-    
+
     // Reset remote stream
     remoteStreamRef.current = new MediaStream();
-    
+
     // Clear remote video elements
     if (remoteVideoRef.current) {
       remoteVideoRef.current.srcObject = null;
@@ -1426,11 +1580,17 @@ export default function Room({
     // If camera is OFF, ensure we clean up any existing video track immediately
     if (!currentCamState) {
       console.log("🚫 CAMERA OFF - Cleaning up video tracks");
-      console.log("📹 Current video track exists:", !!currentVideoTrackRef.current);
-      
+      console.log(
+        "📹 Current video track exists:",
+        !!currentVideoTrackRef.current
+      );
+
       if (currentVideoTrackRef.current) {
         try {
-          console.log("🛑 Stopping video track:", currentVideoTrackRef.current.id);
+          console.log(
+            "🛑 Stopping video track:",
+            currentVideoTrackRef.current.id
+          );
           currentVideoTrackRef.current.stop();
           currentVideoTrackRef.current = null;
           console.log("✅ Video track stopped and cleared");
@@ -1438,13 +1598,16 @@ export default function Room({
           console.error("❌ Error stopping video track:", err);
         }
       }
-      
+
       // Also clean up local video preview to match the off state
       if (localVideoRef.current && localVideoRef.current.srcObject) {
         const ms = localVideoRef.current.srcObject as MediaStream;
         const videoTracks = ms.getVideoTracks();
-        console.log("🎥 Local preview video tracks to remove:", videoTracks.length);
-        
+        console.log(
+          "🎥 Local preview video tracks to remove:",
+          videoTracks.length
+        );
+
         for (const t of videoTracks) {
           try {
             console.log("🗑️ Removing video track from preview:", t.id);
@@ -1458,10 +1621,18 @@ export default function Room({
       }
     } else {
       console.log("✅ CAMERA ON - Preserving video track for next connection");
-      if (!currentVideoTrackRef.current || currentVideoTrackRef.current.readyState === "ended") {
-        console.log("⚠️ Current video track not available, will create new one");
+      if (
+        !currentVideoTrackRef.current ||
+        currentVideoTrackRef.current.readyState === "ended"
+      ) {
+        console.log(
+          "⚠️ Current video track not available, will create new one"
+        );
       } else {
-        console.log("📹 Video track available:", currentVideoTrackRef.current.id);
+        console.log(
+          "📹 Video track available:",
+          currentVideoTrackRef.current.id
+        );
       }
     }
 
@@ -1472,22 +1643,39 @@ export default function Room({
     } else {
       setStatus("Searching for your next match…");
     }
-    
-    console.log("🔄 HANDLE_NEXT_CONNECTION END - States preserved:", { camOn: currentCamState, micOn: currentMicState });
+
+    console.log("🔄 HANDLE_NEXT_CONNECTION END - States preserved:", {
+      camOn: currentCamState,
+      micOn: currentMicState,
+    });
   }
 
-const handleNext = () => {
+  const handleNext = () => {
     const s = socketRef.current;
     if (!s) return;
 
     // Get the actual current states - check if we have active tracks, not just the state variables
-    const actualCamState = !!(currentVideoTrackRef.current && currentVideoTrackRef.current.readyState === "live" && camOn);
-    const actualMicState = !!(localAudioTrack && localAudioTrack.readyState === "live" && micOn);
-    
+    const actualCamState = !!(
+      currentVideoTrackRef.current &&
+      currentVideoTrackRef.current.readyState === "live" &&
+      camOn
+    );
+    const actualMicState = !!(
+      localAudioTrack &&
+      localAudioTrack.readyState === "live" &&
+      micOn
+    );
+
     console.log("🔄 handleNext called - State check:");
     console.log("   - camOn state:", camOn);
-    console.log("   - currentVideoTrack exists:", !!currentVideoTrackRef.current);
-    console.log("   - currentVideoTrack readyState:", currentVideoTrackRef.current?.readyState);
+    console.log(
+      "   - currentVideoTrack exists:",
+      !!currentVideoTrackRef.current
+    );
+    console.log(
+      "   - currentVideoTrack readyState:",
+      currentVideoTrackRef.current?.readyState
+    );
     console.log("   - actual cam state:", actualCamState);
     console.log("   - actual mic state:", actualMicState);
 
@@ -1501,7 +1689,6 @@ const handleNext = () => {
     s.emit("queue:next");
     handleNextConnection(actualCamState, actualMicState, "next"); // Pass actual states based on track availability
   };
-
 
   const handleLeave = () => {
     const s = socketRef.current;
@@ -1522,7 +1709,9 @@ const handleNext = () => {
       }
       if (localScreenShareStreamRef.current) {
         try {
-          localScreenShareStreamRef.current.getTracks().forEach(t => t.stop());
+          localScreenShareStreamRef.current
+            .getTracks()
+            .forEach((t) => t.stop());
         } catch {}
       }
     }
@@ -1567,14 +1756,25 @@ const handleNext = () => {
     try {
       if (s && reporter) {
         // client-side emit; server may or may not handle it depending on setup
-        s.emit("report", { reporterId: reporter, reportedId: reported, roomId, reason });
-        toast.success("Report submitted", { description: "Thank you. We received your report." });
+        s.emit("report", {
+          reporterId: reporter,
+          reportedId: reported,
+          roomId,
+          reason,
+        });
+        toast.success("Report submitted", {
+          description: "Thank you. We received your report.",
+        });
       } else {
-        toast.error("Report failed", { description: "Could not submit report (no socket)." });
+        toast.error("Report failed", {
+          description: "Could not submit report (no socket).",
+        });
       }
     } catch (e) {
       console.error("report emit error", e);
-      try { toast.error("Report failed", { description: "An error occurred." }); } catch {}
+      try {
+        toast.error("Report failed", { description: "An error occurred." });
+      } catch {}
     }
   };
 
@@ -1584,12 +1784,15 @@ const handleNext = () => {
     <div className="relative flex min-h-screen flex-col bg-neutral-950 text-white">
       {/* Main Content Area - Videos and Chat */}
       <main className="relative flex-1">
-        <div className={`relative mx-auto max-w-[1400px] h-[calc(100vh-80px)] transition-all duration-300 ${
-          showChat ? 'px-2 pr-[500px] sm:pr-[500px] md:pr-[540px] lg:pr-[600px]' : 'px-4'
-        } pt-4`}>
-          
+        <div
+          className={`relative mx-auto max-w-[1400px] h-[calc(100vh-80px)] transition-all duration-300 ${
+            showChat
+              ? "px-2 pr-[500px] sm:pr-[500px] md:pr-[540px] lg:pr-[600px]"
+              : "px-4"
+          } pt-4`}
+        >
           {/* Screen Share Layout - matches your image exactly */}
-          {(peerScreenShareOn || screenShareOn) ? (
+          {peerScreenShareOn || screenShareOn ? (
             <div className="flex flex-col h-full gap-4">
               {/* Top: Two small videos side by side */}
               <div className="flex gap-4 justify-center">
@@ -1656,33 +1859,44 @@ const handleNext = () => {
                 <div className="absolute bottom-4 left-4 rounded-md bg-black/60 px-3 py-2 text-sm">
                   <span className="flex items-center gap-2">
                     <IconScreenShare className="h-4 w-4" />
-                    {screenShareOn ? "Your Screen Share" : "Peer's Screen Share"}
+                    {screenShareOn
+                      ? "Your Screen Share"
+                      : "Peer's Screen Share"}
                   </span>
                 </div>
               </div>
             </div>
           ) : (
             /* Regular Video Grid - when not screen sharing */
-            <div className={`grid gap-4 h-full transition-all duration-300 ${
-              showChat 
-                ? 'grid-cols-1 grid-rows-2 max-w-none' 
-                : 'grid-cols-1 sm:grid-cols-2 grid-rows-1'
-            }`}>
+            <div
+              className={`grid gap-4 h-full transition-all duration-300 ${
+                showChat
+                  ? "grid-cols-1 grid-rows-2 max-w-none"
+                  : "grid-cols-1 sm:grid-cols-2 grid-rows-1"
+              }`}
+            >
               {/* Remote/Peer Video */}
-              <div className={`relative overflow-hidden rounded-2xl border border-white/10 bg-black shadow-[0_10px_40px_rgba(0,0,0,0.5)] ${
-                showChat ? 'aspect-[4/3] max-w-2xl mx-auto' : ''
-              }`}>
+              <div
+                className={`relative overflow-hidden rounded-2xl border border-white/10 bg-black shadow-[0_10px_40px_rgba(0,0,0,0.5)] ${
+                  showChat ? "aspect-[4/3] max-w-2xl mx-auto" : ""
+                }`}
+              >
                 {/* Video container with proper aspect ratio */}
-                <div className={`relative w-full ${
-                  showChat ? 'h-full' : 'h-full min-h-0'
-                }`}>
+                <div
+                  className={`relative w-full ${
+                    showChat ? "h-full" : "h-full min-h-0"
+                  }`}
+                >
                   <video
                     ref={remoteVideoRef}
                     autoPlay
                     playsInline
                     className={`absolute inset-0 h-full w-full ${
-                      peerScreenShareOn ? 'object-contain' : 
-                      showChat ? 'object-cover' : 'object-cover'
+                      peerScreenShareOn
+                        ? "object-contain"
+                        : showChat
+                        ? "object-cover"
+                        : "object-cover"
                     }`}
                   />
 
@@ -1693,13 +1907,13 @@ const handleNext = () => {
                       <span className="text-sm text-white/70">{status}</span>
                     </div>
                   )}
-                  
+
                   {!peerCamOn && !lobby && (
                     <div className="absolute inset-0 flex items-center justify-center bg-black">
                       <IconUser className="h-12 w-12 text-white/70" />
                     </div>
                   )}
-                  
+
                   {/* Remote label with mic badge and screen share indicator */}
                   <div className="absolute bottom-3 left-3 flex items-center gap-2 rounded-md bg-black/60 px-2 py-1 text-xs">
                     <span>{lobby ? "—" : "Peer"}</span>
@@ -1720,28 +1934,32 @@ const handleNext = () => {
               </div>
 
               {/* Local/Your Video */}
-              <div className={`relative overflow-hidden rounded-2xl border border-white/10 bg-black shadow-[0_10px_40px_rgba(0,0,0,0.5)] ${
-                showChat ? 'aspect-[4/3] max-w-2xl mx-auto' : ''
-              }`}>
-                <div className={`relative w-full ${
-                  showChat ? 'h-full' : 'h-full min-h-0'
-                }`}>
+              <div
+                className={`relative overflow-hidden rounded-2xl border border-white/10 bg-black shadow-[0_10px_40px_rgba(0,0,0,0.5)] ${
+                  showChat ? "aspect-[4/3] max-w-2xl mx-auto" : ""
+                }`}
+              >
+                <div
+                  className={`relative w-full ${
+                    showChat ? "h-full" : "h-full min-h-0"
+                  }`}
+                >
                   <video
                     ref={localVideoRef}
                     autoPlay
                     playsInline
                     muted
                     className={`absolute inset-0 h-full w-full ${
-                      showChat ? 'object-cover' : 'object-cover'
+                      showChat ? "object-cover" : "object-cover"
                     }`}
                   />
-                  
+
                   {!camOn && (
                     <div className="absolute inset-0 flex items-center justify-center bg-black">
                       <IconUser className="h-12 w-12 text-white/70" />
                     </div>
                   )}
-                  
+
                   {/* Local label with screen share indicator */}
                   <div className="absolute bottom-3 left-3 flex items-center gap-2 rounded-md bg-black/60 px-2 py-1 text-xs">
                     <span>{name || "You"}</span>
@@ -1795,31 +2013,49 @@ const handleNext = () => {
             <button
               onClick={toggleMic}
               className={`h-11 w-11 rounded-full flex items-center justify-center transition ${
-                micOn ? "bg-white/10 hover:bg-white/20" : "bg-red-600 hover:bg-red-500"
+                micOn
+                  ? "bg-white/10 hover:bg-white/20"
+                  : "bg-red-600 hover:bg-red-500"
               }`}
               title={micOn ? "Turn off microphone" : "Turn on microphone"}
             >
-              {micOn ? <IconMicrophone className="h-5 w-5" /> : <IconMicrophoneOff className="h-5 w-5" />}
+              {micOn ? (
+                <IconMicrophone className="h-5 w-5" />
+              ) : (
+                <IconMicrophoneOff className="h-5 w-5" />
+              )}
             </button>
 
             <button
               onClick={toggleCam}
               className={`h-11 w-11 rounded-full flex items-center justify-center transition ${
-                camOn ? "bg-white/10 hover:bg-white/20" : "bg-red-600 hover:bg-red-500"
+                camOn
+                  ? "bg-white/10 hover:bg-white/20"
+                  : "bg-red-600 hover:bg-red-500"
               }`}
               title={camOn ? "Turn off camera" : "Turn on camera"}
             >
-              {camOn ? <IconVideo className="h-5 w-5" /> : <IconVideoOff className="h-5 w-5" />}
+              {camOn ? (
+                <IconVideo className="h-5 w-5" />
+              ) : (
+                <IconVideoOff className="h-5 w-5" />
+              )}
             </button>
 
             <button
               onClick={toggleScreenShare}
               className={`h-11 w-11 rounded-full flex items-center justify-center transition ${
-                screenShareOn ? "bg-blue-600 hover:bg-blue-500" : "bg-white/10 hover:bg-white/20"
+                screenShareOn
+                  ? "bg-blue-600 hover:bg-blue-500"
+                  : "bg-white/10 hover:bg-white/20"
               }`}
               title={screenShareOn ? "Stop screen share" : "Start screen share"}
             >
-              {screenShareOn ? <IconScreenShareOff className="h-5 w-5" /> : <IconScreenShare className="h-5 w-5" />}
+              {screenShareOn ? (
+                <IconScreenShareOff className="h-5 w-5" />
+              ) : (
+                <IconScreenShare className="h-5 w-5" />
+              )}
             </button>
 
             <button
@@ -1836,7 +2072,9 @@ const handleNext = () => {
               title="Leave call"
             >
               <IconPhoneOff className="h-5 w-5" />
-              <span className="hidden sm:inline text-sm font-medium">Leave</span>
+              <span className="hidden sm:inline text-sm font-medium">
+                Leave
+              </span>
             </button>
           </div>
 
@@ -1846,13 +2084,15 @@ const handleNext = () => {
               <button
                 onClick={() => setShowChat((v) => !v)}
                 className={`h-11 w-11 rounded-full flex items-center justify-center transition ${
-                  showChat ? "bg-indigo-600 hover:bg-indigo-500" : "bg-white/10 hover:bg-white/20"
+                  showChat
+                    ? "bg-indigo-600 hover:bg-indigo-500"
+                    : "bg-white/10 hover:bg-white/20"
                 }`}
                 title={showChat ? "Close chat" : "Open chat"}
               >
                 <IconMessage className="h-5 w-5" />
               </button>
-              
+
               <button
                 onClick={() => handleReport()}
                 className="h-11 w-11 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center"
@@ -1866,10 +2106,10 @@ const handleNext = () => {
       </div>
 
       {showTimeoutAlert && (
-        <div 
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm" 
-          role="dialog" 
-          aria-modal="true" 
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
           aria-labelledby="timeout-title"
           onKeyDown={handleKeyDown}
         >
@@ -1878,15 +2118,19 @@ const handleNext = () => {
               <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-orange-600/20">
                 <IconFlag className="h-6 w-6 text-orange-400" />
               </div>
-              
-              <h3 id="timeout-title" className="mb-2 text-lg font-semibold text-white">
+
+              <h3
+                id="timeout-title"
+                className="mb-2 text-lg font-semibold text-white"
+              >
                 No Match Found
               </h3>
-              
+
               <p className="mb-6 text-sm text-neutral-400">
-                {timeoutMessage || "We couldn't find a match right now. Please try again later."}
+                {timeoutMessage ||
+                  "We couldn't find a match right now. Please try again later."}
               </p>
-              
+
               <div className="flex gap-3">
                 <button
                   onClick={handleRetryMatchmaking}


### PR DESCRIPTION
#3  

Problem Description
Two critical issues were affecting the video calling functionality:

getUserMedia Constraint Error: When users toggled both camera and microphone off simultaneously, the application threw an error: "Failed to execute 'getUserMedia' on 'MediaDevices': At least one of audio and video must be requested"

State Synchronization Issue: Camera and microphone states were not properly synchronized between the DeviceCheck component (pre-join device testing) and the Room component (actual video call), causing inconsistent behavior when joining calls.

Solution
Added a guard clause that detects when both media constraints are false and gracefully handles this state by cleaning up existing tracks instead of requesting new media with invalid constraints.
Modified DeviceCheck to pass current boolean states to Room component
Updated Room component to accept and use these initial states instead of defaulting to true and fixed the initial state broadcasting.
Ensured state consistency between device testing and actual call phases
Summary by CodeRabbit
New Features

Respect initial mic/camera settings across Device Check and Room; preview and UI reflect chosen on/off states.
Improved camera toggle and screen-share behavior for more reliable preview and transitions.
Media-state updates are only broadcast after joining a room.
Bug Fixes

Avoids unnecessary camera/mic permission prompts when both are off.
Cleans up local media on exit to prevent lingering device use.
Ensures video preview clears when no video track is available; status indicators reflect muted/off states.
Style

Improved text wrapping and consistent button/indicator styling.
Other

Improved error toasts and more robust logging for diagnosis.