### PR TITLE
Fixed the play/pause button issue on hover

### DIFF
--- a/frontend/components/RTC/DeviceCheck.tsx
+++ b/frontend/components/RTC/DeviceCheck.tsx
@@ -110,7 +110,12 @@ export default function DeviceCheck() {
                     autoPlay
                     playsInline
                     muted
-                    className="absolute inset-0 h-full w-full object-cover"
+                    controls={false}
+                    disablePictureInPicture
+                    controlsList="nodownload noplaybackrate"
+                    className="absolute inset-0 h-full w-full object-cover pointer-events-none"
+                    style={{ pointerEvents: 'none' }}
+                    onContextMenu={(e) => e.preventDefault()}
                   />
                 ) : (
                   <div className="absolute inset-0 flex items-center justify-center bg-black">

--- a/frontend/components/RTC/VideoGrid.tsx
+++ b/frontend/components/RTC/VideoGrid.tsx
@@ -59,7 +59,12 @@ export default function VideoGrid({
               autoPlay
               playsInline
               muted
-              className="absolute inset-0 h-full w-full object-cover"
+              controls={false}
+              disablePictureInPicture
+              controlsList="nodownload noplaybackrate"
+              className="absolute inset-0 h-full w-full object-cover pointer-events-none"
+              style={{ pointerEvents: 'none' }}
+              onContextMenu={(e) => e.preventDefault()}
             />
             {!camOn && (
               <div className="absolute inset-0 flex items-center justify-center bg-black">
@@ -77,7 +82,12 @@ export default function VideoGrid({
               ref={remoteVideoRef}
               autoPlay
               playsInline
-              className="absolute inset-0 h-full w-full object-cover"
+              controls={false}
+              disablePictureInPicture
+              controlsList="nodownload noplaybackrate"
+              className="absolute inset-0 h-full w-full object-cover pointer-events-none"
+              style={{ pointerEvents: 'none' }}
+              onContextMenu={(e) => e.preventDefault()}
             />
             {!peerCamOn && (
               <div className="absolute inset-0 flex items-center justify-center bg-black">
@@ -101,7 +111,12 @@ export default function VideoGrid({
               autoPlay
               playsInline
               muted
-              className="absolute inset-0 h-full w-full object-contain"
+              controls={false}
+              disablePictureInPicture
+              controlsList="nodownload noplaybackrate"
+              className="absolute inset-0 h-full w-full object-contain pointer-events-none"
+              style={{ pointerEvents: 'none' }}
+              onContextMenu={(e) => e.preventDefault()}
             />
           )}
           {peerScreenShareOn && !screenShareOn && (
@@ -109,7 +124,12 @@ export default function VideoGrid({
               ref={remoteScreenShareRef}
               autoPlay
               playsInline
-              className="absolute inset-0 h-full w-full object-contain"
+              controls={false}
+              disablePictureInPicture
+              controlsList="nodownload noplaybackrate"
+              className="absolute inset-0 h-full w-full object-contain pointer-events-none"
+              style={{ pointerEvents: 'none' }}
+              onContextMenu={(e) => e.preventDefault()}
             />
           )}
           <div className="absolute bottom-4 left-4 rounded-md bg-black/60 px-3 py-2 text-sm">
@@ -140,10 +160,15 @@ export default function VideoGrid({
             ref={remoteVideoRef}
             autoPlay
             playsInline
-            className={`absolute inset-0 h-full w-full ${
+            controls={false}
+            disablePictureInPicture
+            controlsList="nodownload noplaybackrate"
+            className={`absolute inset-0 h-full w-full pointer-events-none ${
               peerScreenShareOn ? 'object-contain' : 
               showChat ? 'object-cover' : 'object-cover'
             }`}
+            style={{ pointerEvents: 'none' }}
+            onContextMenu={(e) => e.preventDefault()}
           />
 
           {/* Lobby overlay */}
@@ -191,9 +216,14 @@ export default function VideoGrid({
             autoPlay
             playsInline
             muted
-            className={`absolute inset-0 h-full w-full ${
+            controls={false}
+            disablePictureInPicture
+            controlsList="nodownload noplaybackrate"
+            className={`absolute inset-0 h-full w-full pointer-events-none ${
               showChat ? 'object-cover' : 'object-cover'
             }`}
+            style={{ pointerEvents: 'none' }}
+            onContextMenu={(e) => e.preventDefault()}
           />
           
           {!camOn && (


### PR DESCRIPTION
- This PR removes the play/pause button that was previously displayed on each video in the Device Check screen when hovering over the video grid.
- Solved issue #92 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made all call and screen-share videos view-only: removed playback controls, disabled context menus, and blocked Picture-in-Picture.
  * Prevented unintended interactions by disabling pointer events on video elements.
  * Applied consistently across local, remote, and screen-share videos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->