### PR TITLE
Add system message for users leaving chat and improve join message de…

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1957,6 +1957,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
+      "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/redis-errors": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",


### PR DESCRIPTION
🌟 Pre-submission Checklist
[✅] ⭐ I have starred the repository (mandatory before contributing)
[✅] 💬 I am a member of the Discord server: [Join Here](https://discord.gg/UJfWXRYe)
[✅] 📝 I have signed up at [helixque.netlify.app](https://helixque.netlify.app/)
[✅] 📢 I have checked the #pull-request channel to ensure no one else is working on this issue
[✅] 📝 I have mentioned this PR in the Discord #pull-request channel
Summary
This PR fixes duplicate system messages when a user leaves the chat.
Previously, users would see two notifications:
Your partner left (room-teardown)
Your partner left (leave-button)
To resolve this, I commented out the unnecessary partner:left event listener in chat.tsx because the Room.tsx component already shows a toast notification when a partner leaves.
Now the user will see only one clean notification instead of duplicates.

Type of Changes
[✅] 🚀 Feature addition
[✅] 🐛 Bug fix
Testing Completed
[✅] ✅ I have tested these changes locally
[✅] 🔧 Backend functionality works properly (if applicable)
 🎨 Frontend functionality works properly (if applicable)
 🌐 WebRTC connections work properly (if applicable)
 📱 Tested on different screen sizes/devices
[✅] 🔄 Tested edge cases (disconnections, reconnections, etc.)
[✅] 🧪 All existing functionality remains unaffected
Development Setup Verification
[✅] 📦 Dependencies installed for both frontend and backend
[✅] 🚀 Development servers start without errors
[✅] 🏗️ Code builds successfully
Code Quality
[✅] 📏 Follows existing TypeScript and React patterns
[✅] 📝 Uses meaningful variable and function names
[✅] 💡 Added comments for complex logic
[✅] 🎯 Code is properly formatted
[✅] 🔍 Self-review of the code has been performed
Related Issues
Closes #6 

Screenshots/Videos
<img width="1912" height="1015" alt="Screenshot 2025-10-04 154452" src="https://github.com/user-attachments/assets/fcfbafc1-9655-4a58-b26b-d73d7450522d" />
<img width="1909" height="1009" alt="Screenshot 2025-10-04 154552" src="https://github.com/user-attachments/assets/ce99657a-3524-416c-8395-bba41853d00d" />
<img width="1898" height="1022" alt="Screenshot 2025-10-04 163406" src="https://github.com/user-attachments/assets/3aef6163-6e76-4565-b4ab-b6f62b86469e" />

Additional Notes
In chat.tsx, lines 102–104, 112, and 123 related to the partner:left listener were commented out , similarly in Room.tsx lines 706-708
This avoids redundancy and keeps the chat UI clean.
Chat still works fine, and room exit behavior is now consistent.
Note: For faster PR review and approval, ensure you're active in our Discord server!