### PR TITLE
Fix camera state handling when users click Next #77

### DIFF
--- a/frontend/components/RTC/webrtc-utils.tsx
+++ b/frontend/components/RTC/webrtc-utils.tsx
@@ -207,7 +207,7 @@ export function teardownPeers(
   // Reset UI states
   setters.setShowChat(false);
   setters.setPeerMicOn(true);
-  setters.setPeerCamOn(true);
+  // setters.setPeerCamOn(true);
   setters.setScreenShareOn(false);
   setters.setPeerScreenShareOn(false);
 


### PR DESCRIPTION
fixed issue #77 

## Summary
- Made most changes in room.tsx and looked the flow of media:state in webrtc-utils.tsx and backend/index.ts

## Screenshots/Videos
When top left connected with top right and bottom left with bottom right
<img width="1440" height="805" alt="Screenshot 2025-10-05 at 2 03 35 AM" src="https://github.com/user-attachments/assets/3fcf241a-b11f-436d-991b-250a60ebcf47" />

when top left turned off camera and clicked on next and bottom left also clicked on next. Top left and bottom left got connected, top right and bottom right got connected. 
working as expected behaviour - Top left joined the connection with camera off and bottom left with on so top left video stream is not shown on bottom left. 
<img width="1433" height="802" alt="Screenshot 2025-10-05 at 2 04 15 AM" src="https://github.com/user-attachments/assets/af2833ef-37a3-450d-9e0b-a5580070565b" />
